### PR TITLE
Select-all checkbox fix on /assets page

### DIFF
--- a/src/app/modules/dashboard/assets/assets.component.ts
+++ b/src/app/modules/dashboard/assets/assets.component.ts
@@ -341,7 +341,8 @@ export class AssetsComponent implements OnInit, OnDestroy {
         checkbox.checked = true;
         this.assetsService.selectAsset(checkbox.name);
       });
-      this.assetsService.toggleSelect.next('true');
+      const event = new Event('on:checked');
+      window.dispatchEvent(event);
     } else {
       this.selectAllText = 'Select all';
       table.map((item) => {
@@ -349,7 +350,8 @@ export class AssetsComponent implements OnInit, OnDestroy {
         checkbox.checked = false;
       });
       this.assetsService.unselectAssets();
-      this.assetsService.toggleSelect.next('true');
+      const event = new Event('on:checked');
+      window.dispatchEvent(event);
     }
   }
 

--- a/src/app/shared/directives/onchecked.directive.ts
+++ b/src/app/shared/directives/onchecked.directive.ts
@@ -11,12 +11,12 @@ export class OncheckedDirective {
 
   constructor(private el: ElementRef, private renderer: Renderer2,
     private assets: AssetsService, private administration: AdministrationService) {
-    this.assets.toggleSelect.subscribe(resp => {
-      this.checkboxClicked();
-    });
-    this.administration.toggleSelect.subscribe(resp => {
-      this.checkboxClicked();
-    });
+      window.addEventListener('on:checked', () => {
+        this.checkboxClicked();
+      });
+      this.administration.toggleSelect.subscribe(resp => {
+        this.checkboxClicked();
+      });
   }
 
   @HostListener('change')


### PR DESCRIPTION
Current Behaviour - 
- Select all not working on /assets page, The assets are being selected but checkbox does not update on the page
- As seen on https://dashboard-dev.ambrosus.com/assets

Expected Behaviour - 
- If a user chooses to select all assets, all the assets should be selected and the UI (all checkboxes) should be rendered. 
- As seen on https://dashboard-test.ambrosus.com/assets

https://app.asana.com/0/667697839439226/770600121644460